### PR TITLE
feat: add ExpandTabFunc for custom tab expansion

### DIFF
--- a/tabwrap.go
+++ b/tabwrap.go
@@ -92,6 +92,8 @@ func (c *Condition) ExpandTab(s string) string {
 // The column advances by nSpaces regardless of what fn returns, so the caller
 // is responsible for returning a string whose display width equals nSpaces if
 // alignment matters. Columns reset at each newline.
+//
+// ExpandTabFunc panics if fn is nil.
 func (c *Condition) ExpandTabFunc(s string, fn func(nSpaces int) string) string {
 	opts := c.options()
 	tw := c.tabWidth()

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -82,6 +82,17 @@ func (c *Condition) StringWidth(s string) int {
 // ExpandTab replaces every tab with spaces according to tab stops.
 // Columns reset at each newline.
 func (c *Condition) ExpandTab(s string) string {
+	return c.ExpandTabFunc(s, func(nSpaces int) string {
+		return strings.Repeat(" ", nSpaces)
+	})
+}
+
+// ExpandTabFunc replaces every tab by calling fn with the number of spaces
+// the tab would normally expand to (based on the current column and tab width).
+// The column advances by nSpaces regardless of what fn returns, so the caller
+// is responsible for returning a string whose display width equals nSpaces if
+// alignment matters. Columns reset at each newline.
+func (c *Condition) ExpandTabFunc(s string, fn func(nSpaces int) string) string {
 	opts := c.options()
 	tw := c.tabWidth()
 
@@ -96,11 +107,9 @@ func (c *Condition) ExpandTab(s string) string {
 			b.WriteByte('\n')
 			col = 0
 		case "\t":
-			spaces := tw - col%tw
-			for range spaces {
-				b.WriteByte(' ')
-			}
-			col += spaces
+			nSpaces := tw - col%tw
+			b.WriteString(fn(nSpaces))
+			col += nSpaces
 		default:
 			b.WriteString(v)
 			col += gs.Width()

--- a/tabwrap_test.go
+++ b/tabwrap_test.go
@@ -161,6 +161,16 @@ func TestExpandTabFunc(t *testing.T) {
 			t.Errorf("ExpandTabFunc = %q, want %q", got, want)
 		}
 	})
+
+	t.Run("nil func panics", func(t *testing.T) {
+		t.Parallel()
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("ExpandTabFunc(s, nil) did not panic")
+			}
+		}()
+		c.ExpandTabFunc("a\tb", nil)
+	})
 }
 
 func TestWrap(t *testing.T) {

--- a/tabwrap_test.go
+++ b/tabwrap_test.go
@@ -96,6 +96,70 @@ func TestExpandTab(t *testing.T) {
 	}
 }
 
+func TestExpandTabFunc(t *testing.T) {
+	t.Parallel()
+	c := NewCondition()
+
+	t.Run("arrow marker", func(t *testing.T) {
+		t.Parallel()
+		got := c.ExpandTabFunc("abc\tdef", func(nSpaces int) string {
+			return "→" + strings.Repeat(" ", nSpaces-1)
+		})
+		want := "abc→def"
+		if got != want {
+			t.Errorf("ExpandTabFunc(%q) = %q, want %q", "abc\tdef", got, want)
+		}
+	})
+
+	t.Run("identity with spaces", func(t *testing.T) {
+		t.Parallel()
+		// ExpandTabFunc with spaces should behave identically to ExpandTab
+		input := "a\tbc\t\nde\t"
+		got := c.ExpandTabFunc(input, func(nSpaces int) string {
+			return strings.Repeat(" ", nSpaces)
+		})
+		want := c.ExpandTab(input)
+		if got != want {
+			t.Errorf("ExpandTabFunc with spaces = %q, want %q (same as ExpandTab)", got, want)
+		}
+	})
+
+	t.Run("tab at start", func(t *testing.T) {
+		t.Parallel()
+		got := c.ExpandTabFunc("\thi", func(nSpaces int) string {
+			return "→" + strings.Repeat("·", nSpaces-1)
+		})
+		want := "→···hi"
+		if got != want {
+			t.Errorf("ExpandTabFunc(%q) = %q, want %q", "\thi", got, want)
+		}
+	})
+
+	t.Run("multiple tabs", func(t *testing.T) {
+		t.Parallel()
+		got := c.ExpandTabFunc("a\tb\t", func(nSpaces int) string {
+			return "[" + strings.Repeat("-", nSpaces-2) + "]"
+		})
+		// "a" at col 0, tab nSpaces=3: "[- ]" (but we use nSpaces-2 dashes)
+		// col advances to 4, "b" at col 4, tab nSpaces=3: "[-]"
+		want := "a[-]b[-]"
+		if got != want {
+			t.Errorf("ExpandTabFunc = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("with newline", func(t *testing.T) {
+		t.Parallel()
+		got := c.ExpandTabFunc("ab\t\ncd\t", func(nSpaces int) string {
+			return "→" + strings.Repeat(" ", nSpaces-1)
+		})
+		want := "ab→ \ncd→ "
+		if got != want {
+			t.Errorf("ExpandTabFunc = %q, want %q", got, want)
+		}
+	})
+}
+
 func TestWrap(t *testing.T) {
 	t.Parallel()
 	c := NewCondition()

--- a/tabwrap_test.go
+++ b/tabwrap_test.go
@@ -138,10 +138,13 @@ func TestExpandTabFunc(t *testing.T) {
 	t.Run("multiple tabs", func(t *testing.T) {
 		t.Parallel()
 		got := c.ExpandTabFunc("a\tb\t", func(nSpaces int) string {
+			if nSpaces < 2 {
+				return strings.Repeat(".", nSpaces)
+			}
 			return "[" + strings.Repeat("-", nSpaces-2) + "]"
 		})
-		// "a" at col 0, tab nSpaces=3: "[- ]" (but we use nSpaces-2 dashes)
-		// col advances to 4, "b" at col 4, tab nSpaces=3: "[-]"
+		// "a" at col 1, tab nSpaces=3: "[-]"
+		// col advances to 4, "b" at col 5, tab nSpaces=3: "[-]"
 		want := "a[-]b[-]"
 		if got != want {
 			t.Errorf("ExpandTabFunc = %q, want %q", got, want)


### PR DESCRIPTION
## Summary

- Add `ExpandTabFunc` method to `Condition` that generalizes `ExpandTab` with a callback `func(nSpaces int) string`
- The callback receives the number of spaces a tab would normally expand to, enabling custom tab replacement (e.g., visible markers like `→` + padding)
- Refactor `ExpandTab` to delegate to `ExpandTabFunc`, eliminating duplication

Closes #1

## Example

```go
cond := &tabwrap.Condition{TabWidth: 4}
result := cond.ExpandTabFunc("abc\tdef", func(nSpaces int) string {
    return "→" + strings.Repeat(" ", nSpaces-1)
})
// result: "abc→def"
```

## Test plan

- [x] Existing `TestExpandTab` passes (validates `ExpandTab` delegation is correct)
- [x] New `TestExpandTabFunc` covers: arrow marker, identity with spaces, tab at start, multiple tabs, newlines

🤖 Generated with [Claude Code](https://claude.com/claude-code)