### PR TITLE
chore: miscellaneous improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ func main() {
 | Function | Description |
 |---|---|
 | `StringWidth(s) int` | Display width of s (tab & newline aware) |
+| `ExpandTab(s) string` | Replace tabs with spaces |
+| `ExpandTabFunc(s, fn) string` | Replace tabs using a custom callback |
+| `Wrap(s, width) string` | Wrap to width columns (tabs expanded) |
 | `Truncate(s, maxWidth, tail) string` | Truncate s, append tail if truncated |
 | `FillLeft(s, width) string` | Left-pad with spaces |
 | `FillRight(s, width) string` | Right-pad with spaces |

--- a/README.md
+++ b/README.md
@@ -78,12 +78,14 @@ func main() {
 | `TabWidth` | 4 | Columns per tab stop |
 | `EastAsianWidth` | false | Treat ambiguous EA chars as width 2 |
 | `ControlSequences` | false | Treat 7-bit ANSI escapes as zero-width |
+| `ControlSequences8Bit` | false | Treat 8-bit ECMA-48 escapes as zero-width |
 
 Additional methods:
 
 | Method | Description |
 |---|---|
 | `ExpandTab(s) string` | Replace tabs with spaces |
+| `ExpandTabFunc(s, fn) string` | Replace tabs using a custom callback |
 | `Wrap(s, width) string` | Wrap to width columns (tabs expanded) |
 
 ## Acknowledgements

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -171,8 +171,9 @@ func (c *Condition) Wrap(s string, width int) string {
 		v := gs.Value()
 		w := gs.Width()
 
-		// Track SGR sequences (zero-width escape sequences starting with ESC).
-		if trackSGR && w == 0 && len(v) > 0 && v[0] == '\x1b' {
+		// Track SGR sequences (zero-width escape sequences starting with ESC
+		// or, when ControlSequences8Bit is enabled, with the 8-bit CSI byte 0x9b).
+		if trackSGR && w == 0 && len(v) > 0 && (v[0] == '\x1b' || v[0] == '\x9b') {
 			if isSGR(v) {
 				if isSGRReset(v) {
 					sgrState = sgrState[:0]
@@ -212,14 +213,25 @@ func (c *Condition) Wrap(s string, width int) string {
 }
 
 // isSGR reports whether s is a CSI SGR (Select Graphic Rendition) sequence.
-// SGR sequences have the form ESC [ <params> m.
+// It recognises both 7-bit (ESC [ <params> m) and 8-bit (0x9b <params> m) forms.
 func isSGR(s string) bool {
-	return len(s) >= 3 && s[0] == '\x1b' && s[1] == '[' && s[len(s)-1] == 'm'
+	if len(s) < 2 || s[len(s)-1] != 'm' {
+		return false
+	}
+	// 7-bit: ESC [ ... m
+	if len(s) >= 3 && s[0] == '\x1b' && s[1] == '[' {
+		return true
+	}
+	// 8-bit: 0x9b ... m
+	if s[0] == '\x9b' {
+		return true
+	}
+	return false
 }
 
 // isSGRReset reports whether s is an SGR reset sequence.
 func isSGRReset(s string) bool {
-	return s == "\x1b[0m" || s == "\x1b[m"
+	return s == "\x1b[0m" || s == "\x1b[m" || s == "\x9b0m" || s == "\x9bm"
 }
 
 // Truncate truncates s to fit within maxWidth display columns, appending tail

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -29,6 +29,10 @@ type Condition struct {
 	// as zero-width when true. This allows correct width measurement of
 	// strings containing terminal color codes and other SGR sequences.
 	ControlSequences bool
+	// ControlSequences8Bit treats 8-bit ECMA-48 escape sequences as zero-width
+	// when true. This extends ControlSequences to cover the 8-bit C1 control
+	// codes (0x80–0x9F based sequences).
+	ControlSequences8Bit bool
 }
 
 // NewCondition returns a Condition with default settings (TabWidth = 4).
@@ -45,8 +49,9 @@ func (c *Condition) tabWidth() int {
 
 func (c *Condition) options() displaywidth.Options {
 	return displaywidth.Options{
-		EastAsianWidth:   c.EastAsianWidth,
-		ControlSequences: c.ControlSequences,
+		EastAsianWidth:       c.EastAsianWidth,
+		ControlSequences:     c.ControlSequences,
+		ControlSequences8Bit: c.ControlSequences8Bit,
 	}
 }
 

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -265,6 +265,23 @@ func StringWidth(s string) int {
 	return defaultCondition.StringWidth(s)
 }
 
+// ExpandTab replaces every tab with spaces using default settings.
+func ExpandTab(s string) string {
+	return defaultCondition.ExpandTab(s)
+}
+
+// ExpandTabFunc replaces every tab using a custom callback with default settings.
+//
+// ExpandTabFunc panics if fn is nil.
+func ExpandTabFunc(s string, fn func(nSpaces int) string) string {
+	return defaultCondition.ExpandTabFunc(s, fn)
+}
+
+// Wrap wraps s to fit within width display columns using default settings.
+func Wrap(s string, width int) string {
+	return defaultCondition.Wrap(s, width)
+}
+
 // Truncate truncates s using default settings.
 func Truncate(s string, maxWidth int, tail string) string {
 	return defaultCondition.Truncate(s, maxWidth, tail)

--- a/tabwrap_bench_test.go
+++ b/tabwrap_bench_test.go
@@ -5,24 +5,29 @@ import (
 	"testing"
 )
 
+var (
+	sinkInt    int
+	sinkString string
+)
+
 func BenchmarkStringWidth(b *testing.B) {
 	c := NewCondition()
 
 	b.Run("ascii", func(b *testing.B) {
 		for range b.N {
-			c.StringWidth("hello world, this is a test string")
+			sinkInt = c.StringWidth("hello world, this is a test string")
 		}
 	})
 
 	b.Run("CJK", func(b *testing.B) {
 		for range b.N {
-			c.StringWidth("日本語のテスト文字列です")
+			sinkInt = c.StringWidth("日本語のテスト文字列です")
 		}
 	})
 
 	b.Run("tabs", func(b *testing.B) {
 		for range b.N {
-			c.StringWidth("col1\tcol2\tcol3\tcol4")
+			sinkInt = c.StringWidth("col1\tcol2\tcol3\tcol4")
 		}
 	})
 }
@@ -31,7 +36,7 @@ func BenchmarkExpandTab(b *testing.B) {
 	c := NewCondition()
 	s := "col1\tcol2\tcol3\tcol4"
 	for range b.N {
-		c.ExpandTab(s)
+		sinkString = c.ExpandTab(s)
 	}
 }
 
@@ -42,7 +47,7 @@ func BenchmarkExpandTabFunc(b *testing.B) {
 		return "→" + strings.Repeat(" ", nSpaces-1)
 	}
 	for range b.N {
-		c.ExpandTabFunc(s, fn)
+		sinkString = c.ExpandTabFunc(s, fn)
 	}
 }
 
@@ -51,20 +56,20 @@ func BenchmarkWrap(b *testing.B) {
 
 	b.Run("short", func(b *testing.B) {
 		for range b.N {
-			c.Wrap("hello world", 5)
+			sinkString = c.Wrap("hello world", 5)
 		}
 	})
 
 	b.Run("long", func(b *testing.B) {
 		s := strings.Repeat("hello world ", 20)
 		for range b.N {
-			c.Wrap(s, 40)
+			sinkString = c.Wrap(s, 40)
 		}
 	})
 
 	b.Run("with_tabs", func(b *testing.B) {
 		for range b.N {
-			c.Wrap("col1\tcol2\tcol3\tcol4", 10)
+			sinkString = c.Wrap("col1\tcol2\tcol3\tcol4", 10)
 		}
 	})
 }
@@ -73,7 +78,7 @@ func BenchmarkWrapSGR(b *testing.B) {
 	c := &Condition{TabWidth: 4, ControlSequences: true}
 	s := "\x1b[31m" + strings.Repeat("hello world ", 20) + "\x1b[0m"
 	for range b.N {
-		c.Wrap(s, 40)
+		sinkString = c.Wrap(s, 40)
 	}
 }
 
@@ -82,13 +87,13 @@ func BenchmarkTruncate(b *testing.B) {
 
 	b.Run("no_tab", func(b *testing.B) {
 		for range b.N {
-			c.Truncate("hello world, this is a long string", 10, "...")
+			sinkString = c.Truncate("hello world, this is a long string", 10, "...")
 		}
 	})
 
 	b.Run("with_tab", func(b *testing.B) {
 		for range b.N {
-			c.Truncate("col1\tcol2\tcol3", 10, "...")
+			sinkString = c.Truncate("col1\tcol2\tcol3", 10, "...")
 		}
 	})
 }
@@ -96,6 +101,6 @@ func BenchmarkTruncate(b *testing.B) {
 func BenchmarkFillRight(b *testing.B) {
 	c := NewCondition()
 	for range b.N {
-		c.FillRight("hello", 20)
+		sinkString = c.FillRight("hello", 20)
 	}
 }

--- a/tabwrap_bench_test.go
+++ b/tabwrap_bench_test.go
@@ -1,0 +1,101 @@
+package tabwrap
+
+import (
+	"strings"
+	"testing"
+)
+
+func BenchmarkStringWidth(b *testing.B) {
+	c := NewCondition()
+
+	b.Run("ascii", func(b *testing.B) {
+		for range b.N {
+			c.StringWidth("hello world, this is a test string")
+		}
+	})
+
+	b.Run("CJK", func(b *testing.B) {
+		for range b.N {
+			c.StringWidth("日本語のテスト文字列です")
+		}
+	})
+
+	b.Run("tabs", func(b *testing.B) {
+		for range b.N {
+			c.StringWidth("col1\tcol2\tcol3\tcol4")
+		}
+	})
+}
+
+func BenchmarkExpandTab(b *testing.B) {
+	c := NewCondition()
+	s := "col1\tcol2\tcol3\tcol4"
+	for range b.N {
+		c.ExpandTab(s)
+	}
+}
+
+func BenchmarkExpandTabFunc(b *testing.B) {
+	c := NewCondition()
+	s := "col1\tcol2\tcol3\tcol4"
+	fn := func(nSpaces int) string {
+		return "→" + strings.Repeat(" ", nSpaces-1)
+	}
+	for range b.N {
+		c.ExpandTabFunc(s, fn)
+	}
+}
+
+func BenchmarkWrap(b *testing.B) {
+	c := NewCondition()
+
+	b.Run("short", func(b *testing.B) {
+		for range b.N {
+			c.Wrap("hello world", 5)
+		}
+	})
+
+	b.Run("long", func(b *testing.B) {
+		s := strings.Repeat("hello world ", 20)
+		for range b.N {
+			c.Wrap(s, 40)
+		}
+	})
+
+	b.Run("with_tabs", func(b *testing.B) {
+		for range b.N {
+			c.Wrap("col1\tcol2\tcol3\tcol4", 10)
+		}
+	})
+}
+
+func BenchmarkWrapSGR(b *testing.B) {
+	c := &Condition{TabWidth: 4, ControlSequences: true}
+	s := "\x1b[31m" + strings.Repeat("hello world ", 20) + "\x1b[0m"
+	for range b.N {
+		c.Wrap(s, 40)
+	}
+}
+
+func BenchmarkTruncate(b *testing.B) {
+	c := NewCondition()
+
+	b.Run("no_tab", func(b *testing.B) {
+		for range b.N {
+			c.Truncate("hello world, this is a long string", 10, "...")
+		}
+	})
+
+	b.Run("with_tab", func(b *testing.B) {
+		for range b.N {
+			c.Truncate("col1\tcol2\tcol3", 10, "...")
+		}
+	})
+}
+
+func BenchmarkFillRight(b *testing.B) {
+	c := NewCondition()
+	for range b.N {
+		c.FillRight("hello", 20)
+	}
+}

--- a/tabwrap_test.go
+++ b/tabwrap_test.go
@@ -468,31 +468,27 @@ func TestWrapSGRCarryOver(t *testing.T) {
 			width: 10,
 			want:  dim + "NULL value" + reset + "\n" + dim + " here" + reset,
 		},
-		{
-			name:  "without ControlSequences unchanged",
-			s:     red + "helloworld" + reset,
-			width: 5,
-			// When ControlSequences is false, escape bytes are visible chars
-			// and wrapping happens differently - just verify no crash
-			want:  "", // skip exact match, just verify no panic
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if tt.name == "without ControlSequences unchanged" {
-				noCSI := &Condition{TabWidth: 4, ControlSequences: false}
-				got := noCSI.Wrap(tt.s, tt.width)
-				_ = got // just verify no panic
-				return
-			}
 			got := c.Wrap(tt.s, tt.width)
 			if got != tt.want {
 				t.Errorf("Wrap(%q, %d):\n got  %q\n want %q", tt.s, tt.width, got, tt.want)
 			}
 		})
 	}
+}
+
+func TestWrapWithoutControlSequences(t *testing.T) {
+	t.Parallel()
+	// When ControlSequences is false, escape bytes are visible chars
+	// and wrapping happens differently — just verify no panic.
+	c := &Condition{TabWidth: 4, ControlSequences: false}
+	red := "\x1b[31m"
+	reset := "\x1b[0m"
+	_ = c.Wrap(red+"helloworld"+reset, 5)
 }
 
 func TestWrapSGRCarryOverLineIndependence(t *testing.T) {

--- a/tabwrap_test.go
+++ b/tabwrap_test.go
@@ -303,6 +303,17 @@ func TestPackageLevelFunctions(t *testing.T) {
 	if got := StringWidth("hello"); got != 5 {
 		t.Errorf("StringWidth = %d, want 5", got)
 	}
+	if got := ExpandTab("a\tb"); got != "a   b" {
+		t.Errorf("ExpandTab = %q, want %q", got, "a   b")
+	}
+	if got := ExpandTabFunc("abc\td", func(n int) string {
+		return "→" + strings.Repeat(" ", n-1)
+	}); got != "abc→d" {
+		t.Errorf("ExpandTabFunc = %q, want %q", got, "abc→d")
+	}
+	if got := Wrap("helloworld", 5); got != "hello\nworld" {
+		t.Errorf("Wrap = %q, want %q", got, "hello\nworld")
+	}
 	if got := Truncate("hello world", 8, "..."); got != "hello..." {
 		t.Errorf("Truncate = %q, want %q", got, "hello...")
 	}

--- a/tabwrap_test.go
+++ b/tabwrap_test.go
@@ -378,6 +378,32 @@ func TestControlSequences(t *testing.T) {
 	})
 }
 
+func TestControlSequences8Bit(t *testing.T) {
+	t.Parallel()
+	// 8-bit CSI: 0x9b is the 8-bit equivalent of ESC [
+	csi8 := "\x9b31m"    // 8-bit CSI SGR red
+	reset8 := "\x9b0m"   // 8-bit CSI SGR reset
+	styled := csi8 + "hello" + reset8
+
+	t.Run("without ControlSequences8Bit", func(t *testing.T) {
+		t.Parallel()
+		c := &Condition{TabWidth: 4, ControlSequences: true}
+		got := c.StringWidth(styled)
+		if got <= 5 {
+			t.Errorf("expected width > 5 without ControlSequences8Bit, got %d", got)
+		}
+	})
+
+	t.Run("with ControlSequences8Bit", func(t *testing.T) {
+		t.Parallel()
+		c := &Condition{TabWidth: 4, ControlSequences: true, ControlSequences8Bit: true}
+		got := c.StringWidth(styled)
+		if got != 5 {
+			t.Errorf("StringWidth with ControlSequences8Bit = %d, want 5", got)
+		}
+	})
+}
+
 func TestWrapSGRCarryOver(t *testing.T) {
 	t.Parallel()
 	c := &Condition{TabWidth: 4, ControlSequences: true}

--- a/tabwrap_test.go
+++ b/tabwrap_test.go
@@ -415,6 +415,48 @@ func TestControlSequences8Bit(t *testing.T) {
 	})
 }
 
+func TestWrapSGRCarryOver8Bit(t *testing.T) {
+	t.Parallel()
+	c := &Condition{TabWidth: 4, ControlSequences: true, ControlSequences8Bit: true}
+
+	red8 := "\x9b31m"
+	reset8 := "\x9b0m"
+
+	// emitNewline uses the 7-bit reset (\x1b[0m) which is universally understood,
+	// while replaying the original 8-bit sequences from sgrState.
+	reset7 := "\x1b[0m"
+
+	t.Run("single color wrap", func(t *testing.T) {
+		t.Parallel()
+		got := c.Wrap(red8+"helloworld"+reset8, 5)
+		want := red8 + "hello" + reset7 + "\n" + red8 + "world" + reset8
+		if got != want {
+			t.Errorf("Wrap 8-bit:\n got  %q\n want %q", got, want)
+		}
+	})
+
+	t.Run("line independence", func(t *testing.T) {
+		t.Parallel()
+		input := red8 + "hello world test" + reset8
+		got := c.Wrap(input, 5)
+		lines := strings.Split(got, "\n")
+
+		for i, line := range lines {
+			if !strings.HasPrefix(line, red8) {
+				t.Errorf("line %d %q: does not start with 8-bit red sequence", i, line)
+			}
+			// Reset may be 7-bit (emitNewline) or 8-bit (from input)
+			if !strings.Contains(line, reset7) && !strings.Contains(line, reset8) {
+				t.Errorf("line %d %q: does not contain any reset sequence", i, line)
+			}
+			w := c.StringWidth(line)
+			if w > 5 {
+				t.Errorf("line %d visible width = %d, want <= 5", i, w)
+			}
+		}
+	})
+}
+
 func TestWrapSGRCarryOver(t *testing.T) {
 	t.Parallel()
 	c := &Condition{TabWidth: 4, ControlSequences: true}


### PR DESCRIPTION
## Summary

A collection of improvements addressing API gaps, documentation, test quality, and upstream feature exposure.

### Changes

1. **feat: expose `ControlSequences8Bit` from displaywidth** (1b59f1f)
   - Add `ControlSequences8Bit` field to `Condition`, forwarding the 8-bit ECMA-48 escape sequence option added in displaywidth v0.11.0.

2. **docs: add `ExpandTabFunc` and `ControlSequences8Bit` to README** (e28ece2)
   - Update API tables to include the new method and field.

3. **feat: add package-level `ExpandTab`, `ExpandTabFunc`, and `Wrap`** (7841795)
   - These were missing while `StringWidth`, `Truncate`, `FillLeft`, and `FillRight` already had package-level convenience wrappers.

4. **test: add benchmarks for all public functions** (31118d4)
   - Cover `StringWidth`, `ExpandTab`, `ExpandTabFunc`, `Wrap`, `WrapSGR`, `Truncate`, and `FillRight`.

5. **refactor: separate `ControlSequences=false` test from SGR carry-over table** (0c46d32)
   - Extract the panic-only test into its own `TestWrapWithoutControlSequences`, removing the name-based branch in the table-driven loop.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>