### PR TITLE
Limit Dependabot to security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    # Disable routine version-update PRs; keep Dependabot security updates.
+    open-pull-requests-limit: 0
 
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    # Disable routine version-update PRs; keep Dependabot security updates.
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Summary
- keep Dependabot configured for Go modules and GitHub Actions
- disable routine version-update PRs by setting `open-pull-requests-limit: 0` for both ecosystems
- leave Dependabot security updates enabled while reducing review noise

## Testing
- validated `.github/dependabot.yml` parses as YAML

## Related
- Refs #5