### PR TITLE
Improve 8-bit control sequence wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ func main() {
 | `ControlSequences8Bit` | false | Treat 8-bit ECMA-48 escapes as zero-width |
 
 `ControlSequences8Bit` affects width calculation and wrapping. `Truncate` follows
-[displaywidth] and ignores `ControlSequences8Bit`, because 8-bit C1 bytes can
+[displaywidth] and ignores `ControlSequences8Bit`, even when it is enabled for
+`StringWidth` and `Wrap`. That means 8-bit C1 sequences may measure as
+zero-width or wrap correctly, but still count during truncation. go-tabwrap
+keeps that behavior because parsing raw 8-bit C1 bytes during truncation can
 conflict with UTF-8 byte boundaries.
 
 Additional methods:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Provides `StringWidth`, `ExpandTab`, `Wrap`, `Truncate`, `FillLeft`, and `FillRi
 - **Grapheme-cluster-aware** — emoji sequences and combining characters are measured correctly (via [displaywidth]).
 - **Tab-stop expansion** — every operation handles `\t` as an elastic tab stop, not a single character.
 - **Line wrapping** — `Wrap` breaks text to fit a column width. Tabs are indivisible: if a tab does not fit, it moves to the next line.
-- **ANSI escape sequence aware** — optional `ControlSequences` and `ControlSequences8Bit` modes treat 7-bit and 8-bit ECMA-48 escape sequences as zero-width, allowing correct measurement of styled terminal output. `Wrap` carries SGR state across line breaks, so each output line is independently styled.
+- **ANSI escape sequence aware** — optional `ControlSequences` mode treats 7-bit ECMA-48 escape sequences as zero-width, and optional `ControlSequences8Bit` mode treats 8-bit C1 ECMA-48 escape sequences as zero-width, allowing correct measurement of styled terminal output. `Wrap` carries recognized SGR state across line breaks, so each output line is independently styled.
 - **East Asian Width** — optional treatment of ambiguous characters as double-width.
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Provides `StringWidth`, `ExpandTab`, `Wrap`, `Truncate`, `FillLeft`, and `FillRi
 - **Grapheme-cluster-aware** — emoji sequences and combining characters are measured correctly (via [displaywidth]).
 - **Tab-stop expansion** — every operation handles `\t` as an elastic tab stop, not a single character.
 - **Line wrapping** — `Wrap` breaks text to fit a column width. Tabs are indivisible: if a tab does not fit, it moves to the next line.
-- **ANSI escape sequence aware** — optional `ControlSequences` mode treats SGR and other 7-bit escape sequences as zero-width, allowing correct measurement of styled terminal output. `Wrap` carries SGR state across line breaks, so each output line is independently styled.
+- **ANSI escape sequence aware** — optional `ControlSequences` and `ControlSequences8Bit` modes treat 7-bit and 8-bit ECMA-48 escape sequences as zero-width, allowing correct measurement of styled terminal output. `Wrap` carries SGR state across line breaks, so each output line is independently styled.
 - **East Asian Width** — optional treatment of ambiguous characters as double-width.
 
 ## Install
@@ -82,6 +82,10 @@ func main() {
 | `EastAsianWidth` | false | Treat ambiguous EA chars as width 2 |
 | `ControlSequences` | false | Treat 7-bit ANSI escapes as zero-width |
 | `ControlSequences8Bit` | false | Treat 8-bit ECMA-48 escapes as zero-width |
+
+`ControlSequences8Bit` affects width calculation and wrapping. `Truncate` follows
+[displaywidth] and ignores `ControlSequences8Bit`, because 8-bit C1 bytes can
+conflict with UTF-8 byte boundaries.
 
 Additional methods:
 

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -248,7 +248,10 @@ func isSGRReset(s string) bool {
 // Truncate truncates s to fit within maxWidth display columns, appending tail
 // if truncation occurs. Tabs are expanded before measuring.
 //
-// ControlSequences8Bit follows displaywidth and is ignored here.
+// ControlSequences8Bit follows displaywidth and is ignored here, even when it
+// is enabled for StringWidth and Wrap. This can make 8-bit C1 sequences count
+// as zero-width for measurement but not for truncation; go-tabwrap keeps that
+// behavior to avoid mis-parsing UTF-8 byte sequences as standalone C1 controls.
 func (c *Condition) Truncate(s string, maxWidth int, tail string) string {
 	if maxWidth <= 0 {
 		return tail

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -248,12 +248,15 @@ func (c *Condition) Truncate(s string, maxWidth int, tail string) string {
 		return tail
 	}
 
+	opts := c.options()
+	opts.ControlSequences8Bit = false
+
 	if !strings.Contains(s, "\t") {
-		return c.options().TruncateString(s, maxWidth, tail)
+		return opts.TruncateString(s, maxWidth, tail)
 	}
 
 	expanded := c.ExpandTab(s)
-	return c.options().TruncateString(expanded, maxWidth, tail)
+	return opts.TruncateString(expanded, maxWidth, tail)
 }
 
 // FillLeft pads s on the left with spaces to reach width display columns.

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -29,10 +29,10 @@ type Condition struct {
 	// as zero-width when true. This allows correct width measurement of
 	// strings containing terminal color codes and other SGR sequences.
 	ControlSequences bool
-	// ControlSequences8Bit treats 8-bit ECMA-48 escape sequences as zero-width
-	// when true. This extends ControlSequences to cover the 8-bit C1 control
-	// codes (0x80–0x9F based sequences). Truncate follows displaywidth and
-	// ignores this option.
+	// ControlSequences8Bit treats 8-bit C1 ECMA-48 escape sequences as zero-width
+	// when true. It can be enabled independently of ControlSequences; enabling
+	// both covers both the 7-bit and 8-bit forms. Truncate follows displaywidth
+	// and ignores this option.
 	ControlSequences8Bit bool
 }
 

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -88,7 +88,7 @@ func (c *Condition) StringWidth(s string) int {
 // ExpandTab replaces every tab with spaces according to tab stops.
 // Columns reset at each newline.
 func (c *Condition) ExpandTab(s string) string {
-	return c.ExpandTabFunc(s, func(nSpaces int) string {
+	return c.expandTabFunc(s, c.options(), func(nSpaces int) string {
 		return strings.Repeat(" ", nSpaces)
 	})
 }
@@ -101,7 +101,10 @@ func (c *Condition) ExpandTab(s string) string {
 //
 // ExpandTabFunc panics if fn is nil.
 func (c *Condition) ExpandTabFunc(s string, fn func(nSpaces int) string) string {
-	opts := c.options()
+	return c.expandTabFunc(s, c.options(), fn)
+}
+
+func (c *Condition) expandTabFunc(s string, opts displaywidth.Options, fn func(nSpaces int) string) string {
 	tw := c.tabWidth()
 
 	var b strings.Builder
@@ -135,10 +138,13 @@ func (c *Condition) ExpandTabFunc(s string, fn func(nSpaces int) string) string 
 // Existing newlines are preserved. When width <= 0 the string is returned
 // with tabs expanded but no wrapping applied.
 //
-// When ControlSequences or ControlSequences8Bit is true, SGR (Select Graphic
-// Rendition) state is carried across line breaks: a reset is emitted before
-// each newline and the active SGR sequences are replayed after it. This
-// ensures each output line is independently styled.
+// When control-sequence handling is enabled, Wrap carries across line breaks
+// only those SGR (Select Graphic Rendition) sequences that are recognized as
+// zero-width under the active options: 7-bit sequences when ControlSequences
+// is true, and 8-bit sequences when ControlSequences8Bit is true. For those
+// sequences, a reset is emitted before each newline and the active SGR
+// sequences are replayed after it so each output line remains independently
+// styled.
 func (c *Condition) Wrap(s string, width int) string {
 	if width <= 0 {
 		return c.ExpandTab(s)
@@ -255,7 +261,9 @@ func (c *Condition) Truncate(s string, maxWidth int, tail string) string {
 		return opts.TruncateString(s, maxWidth, tail)
 	}
 
-	expanded := c.ExpandTab(s)
+	expanded := c.expandTabFunc(s, opts, func(nSpaces int) string {
+		return strings.Repeat(" ", nSpaces)
+	})
 	return opts.TruncateString(expanded, maxWidth, tail)
 }
 

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -114,11 +114,9 @@ func (c *Condition) ExpandTab(s string) string {
 // is responsible for returning a string whose display width equals nSpaces if
 // alignment matters. Columns reset at each newline.
 //
-// ExpandTabFunc panics if fn is nil.
+// ExpandTabFunc panics if fn is nil and s contains a tab, because fn is only
+// called when a tab is encountered.
 func (c *Condition) ExpandTabFunc(s string, fn func(nSpaces int) string) string {
-	if fn == nil {
-		panic("tabwrap: nil ExpandTabFunc callback")
-	}
 	return c.expandTabFunc(s, c.options(), fn)
 }
 
@@ -393,7 +391,8 @@ func ExpandTab(s string) string {
 
 // ExpandTabFunc replaces every tab using a custom callback with default settings.
 //
-// ExpandTabFunc panics if fn is nil.
+// ExpandTabFunc panics if fn is nil and s contains a tab, because fn is only
+// called when a tab is encountered.
 func ExpandTabFunc(s string, fn func(nSpaces int) string) string {
 	return defaultCondition.ExpandTabFunc(s, fn)
 }

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -31,7 +31,8 @@ type Condition struct {
 	ControlSequences bool
 	// ControlSequences8Bit treats 8-bit ECMA-48 escape sequences as zero-width
 	// when true. This extends ControlSequences to cover the 8-bit C1 control
-	// codes (0x80–0x9F based sequences).
+	// codes (0x80–0x9F based sequences). Truncate follows displaywidth and
+	// ignores this option.
 	ControlSequences8Bit bool
 }
 
@@ -134,10 +135,10 @@ func (c *Condition) ExpandTabFunc(s string, fn func(nSpaces int) string) string 
 // Existing newlines are preserved. When width <= 0 the string is returned
 // with tabs expanded but no wrapping applied.
 //
-// When ControlSequences is true, SGR (Select Graphic Rendition) state is
-// carried across line breaks: a reset is emitted before each newline and the
-// active SGR sequences are replayed after it. This ensures each output line
-// is independently styled.
+// When ControlSequences or ControlSequences8Bit is true, SGR (Select Graphic
+// Rendition) state is carried across line breaks: a reset is emitted before
+// each newline and the active SGR sequences are replayed after it. This
+// ensures each output line is independently styled.
 func (c *Condition) Wrap(s string, width int) string {
 	if width <= 0 {
 		return c.ExpandTab(s)
@@ -145,7 +146,11 @@ func (c *Condition) Wrap(s string, width int) string {
 
 	opts := c.options()
 	tw := c.tabWidth()
-	trackSGR := c.ControlSequences
+	trackSGR := c.ControlSequences || c.ControlSequences8Bit
+	resetSGR := "\x1b[0m"
+	if c.ControlSequences8Bit && !c.ControlSequences {
+		resetSGR = "\x9b0m"
+	}
 
 	var b strings.Builder
 	b.Grow(len(s))
@@ -156,7 +161,7 @@ func (c *Condition) Wrap(s string, width int) string {
 	// a reset before the newline and replays the current SGR state after it.
 	emitNewline := func() {
 		if trackSGR && len(sgrState) > 0 {
-			b.WriteString("\x1b[0m")
+			b.WriteString(resetSGR)
 		}
 		b.WriteByte('\n')
 		if trackSGR {
@@ -236,6 +241,8 @@ func isSGRReset(s string) bool {
 
 // Truncate truncates s to fit within maxWidth display columns, appending tail
 // if truncation occurs. Tabs are expanded before measuring.
+//
+// ControlSequences8Bit follows displaywidth and is ignored here.
 func (c *Condition) Truncate(s string, maxWidth int, tail string) string {
 	if maxWidth <= 0 {
 		return tail

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -101,6 +101,9 @@ func (c *Condition) ExpandTab(s string) string {
 //
 // ExpandTabFunc panics if fn is nil.
 func (c *Condition) ExpandTabFunc(s string, fn func(nSpaces int) string) string {
+	if fn == nil {
+		panic("tabwrap: nil ExpandTabFunc callback")
+	}
 	return c.expandTabFunc(s, c.options(), fn)
 }
 

--- a/tabwrap_test.go
+++ b/tabwrap_test.go
@@ -435,6 +435,19 @@ func TestControlSequences8Bit(t *testing.T) {
 			t.Errorf("Truncate with ControlSequences8Bit = %q, want %q", got, want)
 		}
 	})
+
+	t.Run("Truncate ignores ControlSequences8Bit with tabs", func(t *testing.T) {
+		t.Parallel()
+		s := csi8 + "a\tbc" + reset8
+		defaultCond := NewCondition()
+		c := &Condition{TabWidth: 4, ControlSequences8Bit: true}
+
+		got := c.Truncate(s, 5, "...")
+		want := defaultCond.Truncate(s, 5, "...")
+		if got != want {
+			t.Errorf("Truncate with ControlSequences8Bit and tabs = %q, want %q", got, want)
+		}
+	})
 }
 
 func TestWrapSGRCarryOver8Bit(t *testing.T) {

--- a/tabwrap_test.go
+++ b/tabwrap_test.go
@@ -181,12 +181,18 @@ func TestExpandTabFunc(t *testing.T) {
 		c.ExpandTabFunc("a\tb", nil)
 	})
 
-	assertPanics(t, "nil func panics without tab", func() {
-		c.ExpandTabFunc("abc", nil)
+	t.Run("nil func without tab does not panic", func(t *testing.T) {
+		t.Parallel()
+		if got := c.ExpandTabFunc("abc", nil); got != "abc" {
+			t.Errorf("ExpandTabFunc without tabs = %q, want %q", got, "abc")
+		}
 	})
 
-	assertPanics(t, "package-level nil func panics without tab", func() {
-		ExpandTabFunc("abc", nil)
+	t.Run("package-level nil func without tab does not panic", func(t *testing.T) {
+		t.Parallel()
+		if got := ExpandTabFunc("abc", nil); got != "abc" {
+			t.Errorf("ExpandTabFunc without tabs = %q, want %q", got, "abc")
+		}
 	})
 }
 

--- a/tabwrap_test.go
+++ b/tabwrap_test.go
@@ -162,14 +162,29 @@ func TestExpandTabFunc(t *testing.T) {
 		}
 	})
 
-	t.Run("nil func panics", func(t *testing.T) {
-		t.Parallel()
-		defer func() {
-			if r := recover(); r == nil {
-				t.Error("ExpandTabFunc(s, nil) did not panic")
-			}
-		}()
+	assertPanics := func(t *testing.T, name string, fn func()) {
+		t.Helper()
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			defer func() {
+				if r := recover(); r == nil {
+					t.Error("ExpandTabFunc(s, nil) did not panic")
+				}
+			}()
+			fn()
+		})
+	}
+
+	assertPanics(t, "nil func panics with tab", func() {
 		c.ExpandTabFunc("a\tb", nil)
+	})
+
+	assertPanics(t, "nil func panics without tab", func() {
+		c.ExpandTabFunc("abc", nil)
+	})
+
+	assertPanics(t, "package-level nil func panics without tab", func() {
+		ExpandTabFunc("abc", nil)
 	})
 }
 

--- a/tabwrap_test.go
+++ b/tabwrap_test.go
@@ -392,8 +392,8 @@ func TestControlSequences(t *testing.T) {
 func TestControlSequences8Bit(t *testing.T) {
 	t.Parallel()
 	// 8-bit CSI: 0x9b is the 8-bit equivalent of ESC [
-	csi8 := "\x9b31m"    // 8-bit CSI SGR red
-	reset8 := "\x9b0m"   // 8-bit CSI SGR reset
+	csi8 := "\x9b31m"  // 8-bit CSI SGR red
+	reset8 := "\x9b0m" // 8-bit CSI SGR reset
 	styled := csi8 + "hello" + reset8
 
 	t.Run("without ControlSequences8Bit", func(t *testing.T) {
@@ -413,48 +413,77 @@ func TestControlSequences8Bit(t *testing.T) {
 			t.Errorf("StringWidth with ControlSequences8Bit = %d, want 5", got)
 		}
 	})
+
+	t.Run("with ControlSequences8Bit only", func(t *testing.T) {
+		t.Parallel()
+		c := &Condition{TabWidth: 4, ControlSequences8Bit: true}
+		got := c.StringWidth(styled)
+		if got != 5 {
+			t.Errorf("StringWidth with ControlSequences8Bit only = %d, want 5", got)
+		}
+	})
 }
 
 func TestWrapSGRCarryOver8Bit(t *testing.T) {
 	t.Parallel()
-	c := &Condition{TabWidth: 4, ControlSequences: true, ControlSequences8Bit: true}
-
 	red8 := "\x9b31m"
 	reset8 := "\x9b0m"
 
-	// emitNewline uses the 7-bit reset (\x1b[0m) which is universally understood,
-	// while replaying the original 8-bit sequences from sgrState.
 	reset7 := "\x1b[0m"
 
-	t.Run("single color wrap", func(t *testing.T) {
-		t.Parallel()
-		got := c.Wrap(red8+"helloworld"+reset8, 5)
-		want := red8 + "hello" + reset7 + "\n" + red8 + "world" + reset8
-		if got != want {
-			t.Errorf("Wrap 8-bit:\n got  %q\n want %q", got, want)
-		}
-	})
+	tests := []struct {
+		name     string
+		c        *Condition
+		resetMid string
+	}{
+		{
+			name:     "with ControlSequences8Bit only",
+			c:        &Condition{TabWidth: 4, ControlSequences8Bit: true},
+			resetMid: reset8,
+		},
+		{
+			name:     "with ControlSequences and ControlSequences8Bit",
+			c:        &Condition{TabWidth: 4, ControlSequences: true, ControlSequences8Bit: true},
+			resetMid: reset7,
+		},
+	}
 
-	t.Run("line independence", func(t *testing.T) {
-		t.Parallel()
-		input := red8 + "hello world test" + reset8
-		got := c.Wrap(input, 5)
-		lines := strings.Split(got, "\n")
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-		for i, line := range lines {
-			if !strings.HasPrefix(line, red8) {
-				t.Errorf("line %d %q: does not start with 8-bit red sequence", i, line)
-			}
-			// Reset may be 7-bit (emitNewline) or 8-bit (from input)
-			if !strings.Contains(line, reset7) && !strings.Contains(line, reset8) {
-				t.Errorf("line %d %q: does not contain any reset sequence", i, line)
-			}
-			w := c.StringWidth(line)
-			if w > 5 {
-				t.Errorf("line %d visible width = %d, want <= 5", i, w)
-			}
-		}
-	})
+			t.Run("single color wrap", func(t *testing.T) {
+				t.Parallel()
+				got := tt.c.Wrap(red8+"helloworld"+reset8, 5)
+				want := red8 + "hello" + tt.resetMid + "\n" + red8 + "world" + reset8
+				if got != want {
+					t.Errorf("Wrap 8-bit:\n got  %q\n want %q", got, want)
+				}
+			})
+
+			t.Run("line independence", func(t *testing.T) {
+				t.Parallel()
+				input := red8 + "hello world test" + reset8
+				got := tt.c.Wrap(input, 5)
+				lines := strings.Split(got, "\n")
+
+				for i, line := range lines {
+					if !strings.HasPrefix(line, red8) {
+						t.Errorf("line %d %q: does not start with 8-bit red sequence", i, line)
+					}
+					// Reset may be 7-bit (emitNewline) or 8-bit (from input)
+					if !strings.Contains(line, reset7) && !strings.Contains(line, reset8) {
+						t.Errorf("line %d %q: does not contain any reset sequence", i, line)
+					}
+					w := tt.c.StringWidth(line)
+					if w > 5 {
+						t.Errorf("line %d visible width = %d, want <= 5", i, w)
+					}
+				}
+			})
+		})
+	}
 }
 
 func TestWrapSGRCarryOver(t *testing.T) {

--- a/tabwrap_test.go
+++ b/tabwrap_test.go
@@ -422,6 +422,19 @@ func TestControlSequences8Bit(t *testing.T) {
 			t.Errorf("StringWidth with ControlSequences8Bit only = %d, want 5", got)
 		}
 	})
+
+	t.Run("Truncate ignores ControlSequences8Bit", func(t *testing.T) {
+		t.Parallel()
+		s := csi8 + "hello world" + reset8
+		defaultCond := NewCondition()
+		c := &Condition{TabWidth: 4, ControlSequences8Bit: true}
+
+		got := c.Truncate(s, 8, "...")
+		want := defaultCond.Truncate(s, 8, "...")
+		if got != want {
+			t.Errorf("Truncate with ControlSequences8Bit = %q, want %q", got, want)
+		}
+	})
 }
 
 func TestWrapSGRCarryOver8Bit(t *testing.T) {

--- a/tabwrap_test.go
+++ b/tabwrap_test.go
@@ -170,7 +170,7 @@ func TestExpandTabFunc(t *testing.T) {
 			t.Parallel()
 			defer func() {
 				if r := recover(); r == nil {
-					t.Error("ExpandTabFunc(s, nil) did not panic")
+					t.Errorf("%s: did not panic", name)
 				}
 			}()
 			fn()


### PR DESCRIPTION
## Summary
- carry 8-bit SGR state across wrapped lines, including 8-bit-only mode
- keep injected resets zero-width for the active control-sequence mode
- document that `Truncate` follows `displaywidth` and ignores `ControlSequences8Bit`
- add tests for `ControlSequences8Bit`-only width and wrap behavior

## Testing
- go test ./...

## Related
- Refs #4