### PR TITLE
Add optional trailing-space trimming for Wrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Provides `StringWidth`, `ExpandTab`, `Wrap`, `Truncate`, `FillLeft`, and `FillRi
 - **Grapheme-cluster-aware** — emoji sequences and combining characters are measured correctly (via [displaywidth]).
 - **Tab-stop expansion** — every operation handles `\t` as an elastic tab stop, not a single character.
 - **Line wrapping** — `Wrap` breaks text to fit a column width. Tabs are indivisible: if a tab does not fit, it moves to the next line.
-- **Optional trailing-space trimming** — `Condition.TrimTrailingSpace` removes trailing spaces and tabs from each wrapped output line.
+- **Optional trailing-space trimming** — `Condition.TrimTrailingSpace` removes trailing spaces and tabs from each output line produced by `Wrap`.
 - **ANSI escape sequence aware** — optional `ControlSequences` mode treats SGR and other 7-bit escape sequences as zero-width, allowing correct measurement of styled terminal output. `Wrap` carries SGR state across line breaks, so each output line is independently styled.
 - **East Asian Width** — optional treatment of ambiguous characters as double-width.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Provides `StringWidth`, `ExpandTab`, `Wrap`, `Truncate`, `FillLeft`, and `FillRi
 - **Grapheme-cluster-aware** — emoji sequences and combining characters are measured correctly (via [displaywidth]).
 - **Tab-stop expansion** — every operation handles `\t` as an elastic tab stop, not a single character.
 - **Line wrapping** — `Wrap` breaks text to fit a column width. Tabs are indivisible: if a tab does not fit, it moves to the next line.
+- **Optional trailing-space trimming** — `Condition.TrimTrailingSpace` removes trailing spaces and tabs from each wrapped output line.
 - **ANSI escape sequence aware** — optional `ControlSequences` mode treats SGR and other 7-bit escape sequences as zero-width, allowing correct measurement of styled terminal output. `Wrap` carries SGR state across line breaks, so each output line is independently styled.
 - **East Asian Width** — optional treatment of ambiguous characters as double-width.
 
@@ -44,6 +45,9 @@ func main() {
 	fmt.Println(c.StringWidth("\t"))            // 8
 	fmt.Println(c.Wrap("hello world", 5))       // "hello\n world"
 	fmt.Println(c.ExpandTab("a\tb"))            // "a       b"
+
+	trimmed := &tabwrap.Condition{TabWidth: 4, TrimTrailingSpace: true}
+	fmt.Println(trimmed.Wrap("ab\tcd", 4))      // "ab\ncd"
 
 	// ANSI escape sequences: measure visible width only.
 	ansi := &tabwrap.Condition{TabWidth: 4, ControlSequences: true}
@@ -82,6 +86,7 @@ func main() {
 | `EastAsianWidth` | false | Treat ambiguous EA chars as width 2 |
 | `ControlSequences` | false | Treat 7-bit ANSI escapes as zero-width |
 | `ControlSequences8Bit` | false | Treat 8-bit ECMA-48 escapes as zero-width |
+| `TrimTrailingSpace` | false | Trim trailing spaces and tabs from each `Wrap` output line |
 
 Additional methods:
 

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -35,7 +35,8 @@ type Condition struct {
 	ControlSequences8Bit bool
 	// TrimTrailingSpace removes trailing spaces and tabs from each output line
 	// produced by Wrap when true. This applies after wrapping, while preserving
-	// trailing zero-width control sequences on the line.
+	// trailing zero-width graphemes on the line (for example, ANSI control
+	// sequences when ControlSequences or ControlSequences8Bit are enabled).
 	TrimTrailingSpace bool
 }
 
@@ -146,7 +147,7 @@ func (c *Condition) Wrap(s string, width int) string {
 	if width <= 0 {
 		result := c.ExpandTab(s)
 		if c.TrimTrailingSpace {
-			return c.trimWrappedLinesRight(result)
+			return trimWrappedLinesRight(result, c.options())
 		}
 		return result
 	}
@@ -219,54 +220,57 @@ func (c *Condition) Wrap(s string, width int) string {
 	}
 	result := b.String()
 	if c.TrimTrailingSpace {
-		return c.trimWrappedLinesRight(result)
+		return trimWrappedLinesRight(result, opts)
 	}
 	return result
 }
 
-func (c *Condition) trimWrappedLinesRight(s string) string {
-	lines := strings.Split(s, "\n")
-	opts := c.options()
+func trimWrappedLinesRight(s string, opts displaywidth.Options) string {
+	var b strings.Builder
+	b.Grow(len(s))
 
-	for i, line := range lines {
-		lines[i] = trimTrailingLineSpace(line, opts)
+	start := 0
+	for {
+		idx := strings.IndexByte(s[start:], '\n')
+		if idx == -1 {
+			b.WriteString(trimTrailingLineSpace(s[start:], opts))
+			return b.String()
+		}
+
+		end := start + idx
+		b.WriteString(trimTrailingLineSpace(s[start:end], opts))
+		b.WriteByte('\n')
+		start = end + 1
 	}
-
-	return strings.Join(lines, "\n")
 }
 
 func trimTrailingLineSpace(s string, opts displaywidth.Options) string {
+	if !opts.ControlSequences && !opts.ControlSequences8Bit {
+		return strings.TrimRight(s, " \t")
+	}
+
 	gs := opts.StringGraphemes(s)
-	graphemes := make([]string, 0, len(s))
-	widths := make([]int, 0, len(s))
+	lastNonSpace := -1
+	count := 0
 
 	for gs.Next() {
-		graphemes = append(graphemes, gs.Value())
-		widths = append(widths, gs.Width())
+		if gs.Width() > 0 && gs.Value() != " " && gs.Value() != "\t" {
+			lastNonSpace = count
+		}
+		count++
 	}
 
-	end := len(graphemes)
-	for end > 0 && widths[end-1] == 0 {
-		end--
-	}
-
-	trimEnd := end
-	for trimEnd > 0 && (graphemes[trimEnd-1] == " " || graphemes[trimEnd-1] == "\t") {
-		trimEnd--
-	}
-
-	if trimEnd == end {
+	if lastNonSpace == count-1 {
 		return s
 	}
 
 	var b strings.Builder
 	b.Grow(len(s))
-
-	for _, g := range graphemes[:trimEnd] {
-		b.WriteString(g)
-	}
-	for _, g := range graphemes[end:] {
-		b.WriteString(g)
+	gs = opts.StringGraphemes(s)
+	for i := 0; gs.Next(); i++ {
+		if i <= lastNonSpace || gs.Width() == 0 {
+			b.WriteString(gs.Value())
+		}
 	}
 
 	return b.String()

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -33,6 +33,10 @@ type Condition struct {
 	// when true. This extends ControlSequences to cover the 8-bit C1 control
 	// codes (0x80–0x9F based sequences).
 	ControlSequences8Bit bool
+	// TrimTrailingSpace removes trailing spaces and tabs from each output line
+	// produced by Wrap when true. This applies after wrapping, while preserving
+	// trailing zero-width control sequences on the line.
+	TrimTrailingSpace bool
 }
 
 // NewCondition returns a Condition with default settings (TabWidth = 4).
@@ -140,7 +144,11 @@ func (c *Condition) ExpandTabFunc(s string, fn func(nSpaces int) string) string 
 // is independently styled.
 func (c *Condition) Wrap(s string, width int) string {
 	if width <= 0 {
-		return c.ExpandTab(s)
+		result := c.ExpandTab(s)
+		if c.TrimTrailingSpace {
+			return c.trimWrappedLinesRight(result)
+		}
+		return result
 	}
 
 	opts := c.options()
@@ -209,6 +217,58 @@ func (c *Condition) Wrap(s string, width int) string {
 			col += w
 		}
 	}
+	result := b.String()
+	if c.TrimTrailingSpace {
+		return c.trimWrappedLinesRight(result)
+	}
+	return result
+}
+
+func (c *Condition) trimWrappedLinesRight(s string) string {
+	lines := strings.Split(s, "\n")
+	opts := c.options()
+
+	for i, line := range lines {
+		lines[i] = trimTrailingLineSpace(line, opts)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func trimTrailingLineSpace(s string, opts displaywidth.Options) string {
+	gs := opts.StringGraphemes(s)
+	graphemes := make([]string, 0, len(s))
+	widths := make([]int, 0, len(s))
+
+	for gs.Next() {
+		graphemes = append(graphemes, gs.Value())
+		widths = append(widths, gs.Width())
+	}
+
+	end := len(graphemes)
+	for end > 0 && widths[end-1] == 0 {
+		end--
+	}
+
+	trimEnd := end
+	for trimEnd > 0 && (graphemes[trimEnd-1] == " " || graphemes[trimEnd-1] == "\t") {
+		trimEnd--
+	}
+
+	if trimEnd == end {
+		return s
+	}
+
+	var b strings.Builder
+	b.Grow(len(s))
+
+	for _, g := range graphemes[:trimEnd] {
+		b.WriteString(g)
+	}
+	for _, g := range graphemes[end:] {
+		b.WriteString(g)
+	}
+
 	return b.String()
 }
 

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -251,16 +251,20 @@ func trimTrailingLineSpace(s string, opts displaywidth.Options) string {
 
 	gs := opts.StringGraphemes(s)
 	lastNonSpace := -1
+	lastVisible := -1
 	count := 0
 
 	for gs.Next() {
-		if gs.Width() > 0 && gs.Value() != " " && gs.Value() != "\t" {
-			lastNonSpace = count
+		if gs.Width() > 0 {
+			lastVisible = count
+			if gs.Value() != " " && gs.Value() != "\t" {
+				lastNonSpace = count
+			}
 		}
 		count++
 	}
 
-	if lastNonSpace == count-1 {
+	if lastVisible == lastNonSpace {
 		return s
 	}
 

--- a/tabwrap_test.go
+++ b/tabwrap_test.go
@@ -209,6 +209,50 @@ func TestWrap(t *testing.T) {
 	}
 }
 
+func TestWrapTrimTrailingSpace(t *testing.T) {
+	t.Parallel()
+
+	t.Run("trimmed plain output", func(t *testing.T) {
+		t.Parallel()
+		c := &Condition{TabWidth: 4, TrimTrailingSpace: true}
+
+		tests := []struct {
+			name  string
+			s     string
+			width int
+			want  string
+		}{
+			{"tab before wrap boundary", "ab\tcd", 4, "ab\ncd"},
+			{"tab at end of line", "abc\t", 4, "abc"},
+			{"natural newline", "ab\t\ncd\t", 10, "ab\ncd"},
+			{"width zero still trims", "abc\t", 0, "abc"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				got := c.Wrap(tt.s, tt.width)
+				if got != tt.want {
+					t.Errorf("Wrap(%q, %d) = %q, want %q", tt.s, tt.width, got, tt.want)
+				}
+			})
+		}
+	})
+
+	t.Run("preserves trailing control sequences", func(t *testing.T) {
+		t.Parallel()
+		c := &Condition{TabWidth: 4, ControlSequences: true, TrimTrailingSpace: true}
+		red := "\x1b[31m"
+		reset := "\x1b[0m"
+
+		got := c.Wrap(red+"ab\tcd"+reset, 4)
+		want := red + "ab" + reset + "\n" + red + "cd" + reset
+		if got != want {
+			t.Errorf("Wrap styled trim = %q, want %q", got, want)
+		}
+	})
+}
+
 func TestTruncate(t *testing.T) {
 	t.Parallel()
 	c := NewCondition()
@@ -392,8 +436,8 @@ func TestControlSequences(t *testing.T) {
 func TestControlSequences8Bit(t *testing.T) {
 	t.Parallel()
 	// 8-bit CSI: 0x9b is the 8-bit equivalent of ESC [
-	csi8 := "\x9b31m"    // 8-bit CSI SGR red
-	reset8 := "\x9b0m"   // 8-bit CSI SGR reset
+	csi8 := "\x9b31m"  // 8-bit CSI SGR red
+	reset8 := "\x9b0m" // 8-bit CSI SGR reset
 	styled := csi8 + "hello" + reset8
 
 	t.Run("without ControlSequences8Bit", func(t *testing.T) {

--- a/tabwrap_test.go
+++ b/tabwrap_test.go
@@ -3,6 +3,8 @@ package tabwrap
 import (
 	"strings"
 	"testing"
+
+	"github.com/clipperhouse/displaywidth"
 )
 
 func TestStringWidth(t *testing.T) {
@@ -229,6 +231,7 @@ func TestWrapTrimTrailingSpace(t *testing.T) {
 		}
 
 		for _, tt := range tests {
+			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 				got := c.Wrap(tt.s, tt.width)
@@ -249,6 +252,17 @@ func TestWrapTrimTrailingSpace(t *testing.T) {
 		want := red + "ab" + reset + "\n" + red + "cd" + reset
 		if got != want {
 			t.Errorf("Wrap styled trim = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("trims spaces around interleaved zero-width sequences", func(t *testing.T) {
+		t.Parallel()
+		opts := displaywidth.Options{ControlSequences: true}
+		input := "ab \x1b[0m \x1b[31m"
+		got := trimTrailingLineSpace(input, opts)
+		want := "ab\x1b[0m\x1b[31m"
+		if got != want {
+			t.Errorf("trimTrailingLineSpace(%q) = %q, want %q", input, got, want)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- add `Condition.TrimTrailingSpace` as an opt-in Wrap normalization knob
- trim trailing spaces and tabs after wrapping while preserving trailing control sequences
- add tests for plain and styled Wrap output
- document the new option in the README

## Testing
- go test ./...

## Related
- Fixes #8