### PR TITLE
Document width semantics more explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ Provides `StringWidth`, `ExpandTab`, `Wrap`, `Truncate`, `FillLeft`, and `FillRi
 - **ANSI escape sequence aware** — optional `ControlSequences` mode treats SGR and other 7-bit escape sequences as zero-width, allowing correct measurement of styled terminal output. `Wrap` carries SGR state across line breaks, so each output line is independently styled.
 - **East Asian Width** — optional treatment of ambiguous characters as double-width.
 
+## Width semantics
+
+`StringWidth` measures terminal display columns by **grapheme cluster**, not by
+rune count. That means emoji sequences, combining characters, and other
+multi-rune graphemes are counted as a single visible unit according to
+[displaywidth].
+
+Tabs expand to tab stops, newlines reset the column, and the width of a
+multi-line string is the width of its widest line. `EastAsianWidth`,
+`ControlSequences`, and `ControlSequences8Bit` adjust how individual graphemes
+are counted, and `FillLeft`, `FillRight`, and `Wrap` all use the same width
+model.
+
 ## Install
 
 ```

--- a/README.md
+++ b/README.md
@@ -114,3 +114,5 @@ This package stands on the shoulders of:
 ## License
 
 MIT
+
+[displaywidth]: https://github.com/clipperhouse/displaywidth

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Provides `StringWidth`, `ExpandTab`, `Wrap`, `Truncate`, `FillLeft`, and `FillRi
 `StringWidth` measures terminal display columns by **grapheme cluster**, not by
 rune count. That means emoji sequences, combining characters, and other
 multi-rune graphemes are counted as a single visible unit according to
-[displaywidth].
+[displaywidth](https://github.com/clipperhouse/displaywidth).
 
 Tabs expand to tab stops, newlines reset the column, and the width of a
 multi-line string is the width of its widest line. `EastAsianWidth`,

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -7,9 +7,9 @@
 //
 // Width is measured in terminal display columns, by grapheme cluster rather
 // than rune. Tabs expand to tab stops, newlines reset the column, and the
-// width of a multi-line string is the width of its widest line. East Asian
-// ambiguous width and ECMA-48 control-sequence handling follows the active
-// [Condition] options.
+// width of a multi-line string is the width of its widest line. The handling
+// of East Asian ambiguous width and ECMA-48 control sequences follows the
+// active [Condition] options.
 //
 // Key differences from [mattn/go-runewidth]:
 //   - Grapheme-cluster-aware (emoji, combining characters) via displaywidth.
@@ -260,7 +260,8 @@ func (c *Condition) Truncate(s string, maxWidth int, tail string) string {
 }
 
 // FillLeft pads s on the left with spaces to reach width display columns.
-// For multi-line strings, only the first line is padded.
+// For multi-line strings, padding is computed from the widest line but is
+// added only at the start of the full string, so only the first line changes.
 // Width is measured using the same rules as [Condition.StringWidth].
 // If s is already at least width columns wide it is returned unchanged.
 func (c *Condition) FillLeft(s string, width int) string {
@@ -272,7 +273,8 @@ func (c *Condition) FillLeft(s string, width int) string {
 }
 
 // FillRight pads s on the right with spaces to reach width display columns.
-// For multi-line strings, only the last line is padded.
+// For multi-line strings, padding is computed from the widest line but is
+// added only at the end of the full string, so only the last line changes.
 // Width is measured using the same rules as [Condition.StringWidth].
 // If s is already at least width columns wide it is returned unchanged.
 func (c *Condition) FillRight(s string, width int) string {

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -5,6 +5,12 @@
 // truncation, and padding — the common building blocks for CLI table renderers
 // and TUI applications.
 //
+// Width is measured in terminal display columns, by grapheme cluster rather
+// than rune. Tabs expand to tab stops, newlines reset the column, and the
+// width of a multi-line string is the width of its widest line. East Asian
+// ambiguous width and ECMA-48 control-sequence handling follow the active
+// [Condition] options.
+//
 // Key differences from [mattn/go-runewidth]:
 //   - Grapheme-cluster-aware (emoji, combining characters) via displaywidth.
 //   - Built-in tab-stop expansion in every operation.
@@ -55,8 +61,12 @@ func (c *Condition) options() displaywidth.Options {
 	}
 }
 
-// StringWidth returns the display width of s, handling tabs and newlines.
-// For multi-line strings it returns the width of the widest line.
+// StringWidth returns the display width of s in terminal columns.
+//
+// Width is measured by grapheme cluster, not rune. Tabs expand to tab stops,
+// newlines reset the column, and for multi-line strings the result is the
+// width of the widest line. EastAsianWidth, ControlSequences, and
+// ControlSequences8Bit affect how individual graphemes are counted.
 func (c *Condition) StringWidth(s string) int {
 	opts := c.options()
 	tw := c.tabWidth()
@@ -250,6 +260,7 @@ func (c *Condition) Truncate(s string, maxWidth int, tail string) string {
 }
 
 // FillLeft pads s on the left with spaces to reach width display columns.
+// Width is measured using the same rules as [Condition.StringWidth].
 // If s is already at least width columns wide it is returned unchanged.
 func (c *Condition) FillLeft(s string, width int) string {
 	w := c.StringWidth(s)
@@ -260,6 +271,7 @@ func (c *Condition) FillLeft(s string, width int) string {
 }
 
 // FillRight pads s on the right with spaces to reach width display columns.
+// Width is measured using the same rules as [Condition.StringWidth].
 // If s is already at least width columns wide it is returned unchanged.
 func (c *Condition) FillRight(s string, width int) string {
 	w := c.StringWidth(s)
@@ -273,6 +285,7 @@ func (c *Condition) FillRight(s string, width int) string {
 var defaultCondition = NewCondition()
 
 // StringWidth returns the display width of s using default settings.
+// See [Condition.StringWidth] for the width model.
 func StringWidth(s string) int {
 	return defaultCondition.StringWidth(s)
 }

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -8,7 +8,7 @@
 // Width is measured in terminal display columns, by grapheme cluster rather
 // than rune. Tabs expand to tab stops, newlines reset the column, and the
 // width of a multi-line string is the width of its widest line. East Asian
-// ambiguous width and ECMA-48 control-sequence handling follow the active
+// ambiguous width and ECMA-48 control-sequence handling follows the active
 // [Condition] options.
 //
 // Key differences from [mattn/go-runewidth]:
@@ -260,6 +260,7 @@ func (c *Condition) Truncate(s string, maxWidth int, tail string) string {
 }
 
 // FillLeft pads s on the left with spaces to reach width display columns.
+// For multi-line strings, only the first line is padded.
 // Width is measured using the same rules as [Condition.StringWidth].
 // If s is already at least width columns wide it is returned unchanged.
 func (c *Condition) FillLeft(s string, width int) string {
@@ -271,6 +272,7 @@ func (c *Condition) FillLeft(s string, width int) string {
 }
 
 // FillRight pads s on the right with spaces to reach width display columns.
+// For multi-line strings, only the last line is padded.
 // Width is measured using the same rules as [Condition.StringWidth].
 // If s is already at least width columns wide it is returned unchanged.
 func (c *Condition) FillRight(s string, width int) string {


### PR DESCRIPTION
## Summary
- explain `StringWidth` in terms of grapheme clusters instead of rune count
- document tab, newline, East Asian width, and control-sequence effects on width
- note that `FillLeft` and `FillRight` use the same width model

## Testing
- go test ./...

## Related
- Fixes #9