### PR TITLE
Fix padding and truncation edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ func main() {
 | `ExpandTab(s) string` | Replace tabs with spaces |
 | `ExpandTabFunc(s, fn) string` | Replace tabs using a custom callback |
 | `Wrap(s, width) string` | Wrap to width columns (tabs expanded) |
-| `Truncate(s, maxWidth, tail) string` | Truncate s, append tail if truncated |
+| `Truncate(s, maxWidth, tail) string` | Truncate s, append tail if truncated, and keep the result within `maxWidth` |
 | `FillLeft(s, width) string` | Left-pad with spaces |
 | `FillRight(s, width) string` | Right-pad with spaces |
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ func main() {
 | `ExpandTab(s) string` | Replace tabs with spaces |
 | `ExpandTabFunc(s, fn) string` | Replace tabs using a custom callback |
 | `Wrap(s, width) string` | Wrap to width columns (tabs expanded) |
-| `Truncate(s, maxWidth, tail) string` | Truncate s, append tail if truncated, and keep the result within `maxWidth` |
+| `Truncate(s, maxWidth, tail) string` | Truncate s, append tail if truncated, and for positive `maxWidth` keep the result within `maxWidth` (`maxWidth <= 0` returns `tail` as-is) |
 | `FillLeft(s, width) string` | Left-pad with spaces |
 | `FillRight(s, width) string` | Right-pad with spaces |
 

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -364,7 +364,6 @@ func (c *Condition) Truncate(s string, maxWidth int, tail string) string {
 // rules as [Condition.StringWidth]. When left padding is needed, tabs in the
 // first line are expanded first so the added spaces do not shift later tab
 // stops there.
-// If s is already at least width columns wide it is returned unchanged.
 func (c *Condition) FillLeft(s string, width int) string {
 	if c.StringWidth(s) >= width {
 		return s

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -387,13 +387,18 @@ func (c *Condition) Truncate(s string, maxWidth int, tail string) string {
 // first line are expanded first so the added spaces do not shift later tab
 // stops there.
 func (c *Condition) FillLeft(s string, width int) string {
-	if c.StringWidth(s) >= width {
+	sw := c.StringWidth(s)
+	if sw >= width {
 		return s
 	}
 	first, rest, found := strings.Cut(s, "\n")
-	firstWidth := c.StringWidth(first)
+	var firstWidth int
 	if strings.Contains(first, "\t") {
 		first, firstWidth = c.expandTabLineAndWidth(first, c.options())
+	} else if !found {
+		firstWidth = sw
+	} else {
+		firstWidth = c.StringWidth(first)
 	}
 	pad := width - firstWidth
 	var b strings.Builder

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -358,27 +358,31 @@ func (c *Condition) Truncate(s string, maxWidth int, tail string) string {
 }
 
 // FillLeft pads s on the left with spaces to reach width display columns.
-// For multi-line strings, padding is computed from the widest line but is
-// added only at the start of the full string, so only the first line changes.
-// Width is measured using the same rules as [Condition.StringWidth]. When left
-// padding is needed, tabs in the first line are expanded first so the added
-// spaces do not shift later tab stops there.
+// For multi-line strings, padding is added only at the start of the full
+// string, so only the first line changes. If another line is already at least
+// width columns wide, s is returned unchanged. Width is measured using the same
+// rules as [Condition.StringWidth]. When left padding is needed, tabs in the
+// first line are expanded first so the added spaces do not shift later tab
+// stops there.
 // If s is already at least width columns wide it is returned unchanged.
 func (c *Condition) FillLeft(s string, width int) string {
-	w := c.StringWidth(s)
-	if w >= width {
+	if c.StringWidth(s) >= width {
 		return s
 	}
 	first, rest, found := strings.Cut(s, "\n")
 	if strings.Contains(first, "\t") {
 		first = c.ExpandTab(first)
-		if found {
-			s = first + "\n" + rest
-		} else {
-			s = first
-		}
 	}
-	return strings.Repeat(" ", width-w) + s
+	pad := width - c.StringWidth(first)
+	var b strings.Builder
+	b.Grow(len(s) + pad)
+	b.WriteString(strings.Repeat(" ", pad))
+	b.WriteString(first)
+	if found {
+		b.WriteByte('\n')
+		b.WriteString(rest)
+	}
+	return b.String()
 }
 
 // FillRight pads s on the right with spaces to reach width display columns.

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -324,9 +324,10 @@ func isSGRReset(s string) bool {
 	return s == "\x1b[0m" || s == "\x1b[m" || s == "\x9b0m" || s == "\x9bm"
 }
 
-// Truncate truncates s to fit within maxWidth display columns, appending tail
-// if truncation occurs. Tabs are expanded before measuring. If tail itself is
-// too wide to fit, it is truncated first so the result still fits maxWidth.
+// Truncate truncates s to fit within positive maxWidth display columns,
+// appending tail if truncation occurs. Tabs are expanded before measuring. If
+// tail itself is too wide to fit, it is truncated first so the result still
+// fits maxWidth. When maxWidth <= 0, tail is returned as-is.
 //
 // ControlSequences8Bit follows displaywidth and is ignored here, even when it
 // is enabled for StringWidth and Wrap. This can make 8-bit C1 sequences count
@@ -360,16 +361,22 @@ func (c *Condition) Truncate(s string, maxWidth int, tail string) string {
 // For multi-line strings, padding is computed from the widest line but is
 // added only at the start of the full string, so only the first line changes.
 // Width is measured using the same rules as [Condition.StringWidth]. When left
-// padding is needed, tabs are expanded first so the added spaces do not shift
-// later tab stops.
+// padding is needed, tabs in the first line are expanded first so the added
+// spaces do not shift later tab stops there.
 // If s is already at least width columns wide it is returned unchanged.
 func (c *Condition) FillLeft(s string, width int) string {
 	w := c.StringWidth(s)
 	if w >= width {
 		return s
 	}
-	if strings.Contains(s, "\t") {
-		s = c.ExpandTab(s)
+	first, rest, found := strings.Cut(s, "\n")
+	if strings.Contains(first, "\t") {
+		first = c.ExpandTab(first)
+		if found {
+			s = first + "\n" + rest
+		} else {
+			s = first
+		}
 	}
 	return strings.Repeat(" ", width-w) + s
 }

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -124,16 +124,25 @@ func (c *Condition) ExpandTabFunc(s string, fn func(nSpaces int) string) string 
 }
 
 func (c *Condition) expandTabFunc(s string, opts displaywidth.Options, fn func(nSpaces int) string) string {
+	expanded, _ := c.expandTabFuncAndWidth(s, opts, fn)
+	return expanded
+}
+
+func (c *Condition) expandTabFuncAndWidth(s string, opts displaywidth.Options, fn func(nSpaces int) string) (string, int) {
 	tw := c.tabWidth()
 
 	var b strings.Builder
 	b.Grow(len(s))
 	col := 0
+	maxW := 0
 	gs := opts.StringGraphemes(s)
 	for gs.Next() {
 		v := gs.Value()
 		switch v {
 		case "\n":
+			if col > maxW {
+				maxW = col
+			}
 			b.WriteByte('\n')
 			col = 0
 		case "\t":
@@ -145,37 +154,21 @@ func (c *Condition) expandTabFunc(s string, opts displaywidth.Options, fn func(n
 			col += gs.Width()
 		}
 	}
-	return b.String()
+	if col > maxW {
+		maxW = col
+	}
+	return b.String(), maxW
 }
 
 func (c *Condition) expandTabSpacesWithOptions(s string, opts displaywidth.Options) string {
-	return c.expandTabFunc(s, opts, func(nSpaces int) string {
-		return strings.Repeat(" ", nSpaces)
-	})
+	expanded, _ := c.expandTabSpacesWithOptionsAndWidth(s, opts)
+	return expanded
 }
 
-// expandTabFirstLineAndWidth assumes s is a single line.
-// FillLeft splits at the first newline before calling it.
-func (c *Condition) expandTabFirstLineAndWidth(s string, opts displaywidth.Options) (string, int) {
-	tw := c.tabWidth()
-
-	var b strings.Builder
-	b.Grow(len(s))
-	col := 0
-	gs := opts.StringGraphemes(s)
-	for gs.Next() {
-		v := gs.Value()
-		switch v {
-		case "\t":
-			nSpaces := tw - col%tw
-			b.WriteString(strings.Repeat(" ", nSpaces))
-			col += nSpaces
-		default:
-			b.WriteString(v)
-			col += gs.Width()
-		}
-	}
-	return b.String(), col
+func (c *Condition) expandTabSpacesWithOptionsAndWidth(s string, opts displaywidth.Options) (string, int) {
+	return c.expandTabFuncAndWidth(s, opts, func(nSpaces int) string {
+		return strings.Repeat(" ", nSpaces)
+	})
 }
 
 // Wrap wraps s to fit within width display columns.
@@ -402,7 +395,7 @@ func (c *Condition) FillLeft(s string, width int) string {
 	first, rest, found := strings.Cut(s, "\n")
 	var firstWidth int
 	if strings.Contains(first, "\t") {
-		first, firstWidth = c.expandTabFirstLineAndWidth(first, opts)
+		first, firstWidth = c.expandTabSpacesWithOptionsAndWidth(first, opts)
 	} else if !found {
 		firstWidth = sw
 	} else {

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -154,7 +154,7 @@ func (c *Condition) expandTabSpacesWithOptions(s string, opts displaywidth.Optio
 	})
 }
 
-func (c *Condition) expandTabLineAndWidth(s string, opts displaywidth.Options) (string, int) {
+func (c *Condition) expandTabFirstLineAndWidth(s string, opts displaywidth.Options) (string, int) {
 	tw := c.tabWidth()
 
 	var b strings.Builder
@@ -400,7 +400,7 @@ func (c *Condition) FillLeft(s string, width int) string {
 	first, rest, found := strings.Cut(s, "\n")
 	var firstWidth int
 	if strings.Contains(first, "\t") {
-		first, firstWidth = c.expandTabLineAndWidth(first, opts)
+		first, firstWidth = c.expandTabFirstLineAndWidth(first, opts)
 	} else if !found {
 		firstWidth = sw
 	} else {

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -325,7 +325,8 @@ func isSGRReset(s string) bool {
 }
 
 // Truncate truncates s to fit within maxWidth display columns, appending tail
-// if truncation occurs. Tabs are expanded before measuring.
+// if truncation occurs. Tabs are expanded before measuring. If tail itself is
+// too wide to fit, it is truncated first so the result still fits maxWidth.
 //
 // ControlSequences8Bit follows displaywidth and is ignored here, even when it
 // is enabled for StringWidth and Wrap. This can make 8-bit C1 sequences count
@@ -338,6 +339,12 @@ func (c *Condition) Truncate(s string, maxWidth int, tail string) string {
 
 	opts := c.options()
 	opts.ControlSequences8Bit = false
+	if strings.Contains(tail, "\t") {
+		tail = c.expandTabFunc(tail, opts, func(nSpaces int) string {
+			return strings.Repeat(" ", nSpaces)
+		})
+	}
+	tail = opts.TruncateString(tail, maxWidth, "")
 
 	if !strings.Contains(s, "\t") {
 		return opts.TruncateString(s, maxWidth, tail)
@@ -352,12 +359,17 @@ func (c *Condition) Truncate(s string, maxWidth int, tail string) string {
 // FillLeft pads s on the left with spaces to reach width display columns.
 // For multi-line strings, padding is computed from the widest line but is
 // added only at the start of the full string, so only the first line changes.
-// Width is measured using the same rules as [Condition.StringWidth].
+// Width is measured using the same rules as [Condition.StringWidth]. When left
+// padding is needed, tabs are expanded first so the added spaces do not shift
+// later tab stops.
 // If s is already at least width columns wide it is returned unchanged.
 func (c *Condition) FillLeft(s string, width int) string {
 	w := c.StringWidth(s)
 	if w >= width {
 		return s
+	}
+	if strings.Contains(s, "\t") {
+		s = c.ExpandTab(s)
 	}
 	return strings.Repeat(" ", width-w) + s
 }

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -145,6 +145,28 @@ func (c *Condition) expandTabFunc(s string, opts displaywidth.Options, fn func(n
 	return b.String()
 }
 
+func (c *Condition) expandTabLineAndWidth(s string, opts displaywidth.Options) (string, int) {
+	tw := c.tabWidth()
+
+	var b strings.Builder
+	b.Grow(len(s))
+	col := 0
+	gs := opts.StringGraphemes(s)
+	for gs.Next() {
+		v := gs.Value()
+		switch v {
+		case "\t":
+			nSpaces := tw - col%tw
+			b.WriteString(strings.Repeat(" ", nSpaces))
+			col += nSpaces
+		default:
+			b.WriteString(v)
+			col += gs.Width()
+		}
+	}
+	return b.String(), col
+}
+
 // Wrap wraps s to fit within width display columns.
 //
 // Tabs are indivisible tokens: if a tab does not fit on the current line the
@@ -369,12 +391,17 @@ func (c *Condition) FillLeft(s string, width int) string {
 		return s
 	}
 	first, rest, found := strings.Cut(s, "\n")
+	firstWidth := c.StringWidth(first)
 	if strings.Contains(first, "\t") {
-		first = c.ExpandTab(first)
+		first, firstWidth = c.expandTabLineAndWidth(first, c.options())
 	}
-	pad := width - c.StringWidth(first)
+	pad := width - firstWidth
 	var b strings.Builder
-	b.Grow(len(s) + pad)
+	totalLen := len(first) + pad
+	if found {
+		totalLen += 1 + len(rest)
+	}
+	b.Grow(totalLen)
 	b.WriteString(strings.Repeat(" ", pad))
 	b.WriteString(first)
 	if found {

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -154,6 +154,8 @@ func (c *Condition) expandTabSpacesWithOptions(s string, opts displaywidth.Optio
 	})
 }
 
+// expandTabFirstLineAndWidth assumes s is a single line.
+// FillLeft splits at the first newline before calling it.
 func (c *Condition) expandTabFirstLineAndWidth(s string, opts displaywidth.Options) (string, int) {
 	tw := c.tabWidth()
 

--- a/tabwrap.go
+++ b/tabwrap.go
@@ -67,14 +67,7 @@ func (c *Condition) options() displaywidth.Options {
 	}
 }
 
-// StringWidth returns the display width of s in terminal columns.
-//
-// Width is measured by grapheme cluster, not rune. Tabs expand to tab stops,
-// newlines reset the column, and for multi-line strings the result is the
-// width of the widest line. EastAsianWidth, ControlSequences, and
-// ControlSequences8Bit affect how individual graphemes are counted.
-func (c *Condition) StringWidth(s string) int {
-	opts := c.options()
+func (c *Condition) stringWidth(s string, opts displaywidth.Options) int {
 	tw := c.tabWidth()
 
 	maxW := 0
@@ -98,6 +91,16 @@ func (c *Condition) StringWidth(s string) int {
 		maxW = col
 	}
 	return maxW
+}
+
+// StringWidth returns the display width of s in terminal columns.
+//
+// Width is measured by grapheme cluster, not rune. Tabs expand to tab stops,
+// newlines reset the column, and for multi-line strings the result is the
+// width of the widest line. EastAsianWidth, ControlSequences, and
+// ControlSequences8Bit affect how individual graphemes are counted.
+func (c *Condition) StringWidth(s string) int {
+	return c.stringWidth(s, c.options())
 }
 
 // ExpandTab replaces every tab with spaces according to tab stops.
@@ -143,6 +146,12 @@ func (c *Condition) expandTabFunc(s string, opts displaywidth.Options, fn func(n
 		}
 	}
 	return b.String()
+}
+
+func (c *Condition) expandTabSpacesWithOptions(s string, opts displaywidth.Options) string {
+	return c.expandTabFunc(s, opts, func(nSpaces int) string {
+		return strings.Repeat(" ", nSpaces)
+	})
 }
 
 func (c *Condition) expandTabLineAndWidth(s string, opts displaywidth.Options) (string, int) {
@@ -363,9 +372,7 @@ func (c *Condition) Truncate(s string, maxWidth int, tail string) string {
 	opts := c.options()
 	opts.ControlSequences8Bit = false
 	if strings.Contains(tail, "\t") {
-		tail = c.expandTabFunc(tail, opts, func(nSpaces int) string {
-			return strings.Repeat(" ", nSpaces)
-		})
+		tail = c.expandTabSpacesWithOptions(tail, opts)
 	}
 	tail = opts.TruncateString(tail, maxWidth, "")
 
@@ -373,9 +380,7 @@ func (c *Condition) Truncate(s string, maxWidth int, tail string) string {
 		return opts.TruncateString(s, maxWidth, tail)
 	}
 
-	expanded := c.expandTabFunc(s, opts, func(nSpaces int) string {
-		return strings.Repeat(" ", nSpaces)
-	})
+	expanded := c.expandTabSpacesWithOptions(s, opts)
 	return opts.TruncateString(expanded, maxWidth, tail)
 }
 
@@ -387,18 +392,19 @@ func (c *Condition) Truncate(s string, maxWidth int, tail string) string {
 // first line are expanded first so the added spaces do not shift later tab
 // stops there.
 func (c *Condition) FillLeft(s string, width int) string {
-	sw := c.StringWidth(s)
+	opts := c.options()
+	sw := c.stringWidth(s, opts)
 	if sw >= width {
 		return s
 	}
 	first, rest, found := strings.Cut(s, "\n")
 	var firstWidth int
 	if strings.Contains(first, "\t") {
-		first, firstWidth = c.expandTabLineAndWidth(first, c.options())
+		first, firstWidth = c.expandTabLineAndWidth(first, opts)
 	} else if !found {
 		firstWidth = sw
 	} else {
-		firstWidth = c.StringWidth(first)
+		firstWidth = c.stringWidth(first, opts)
 	}
 	pad := width - firstWidth
 	var b strings.Builder

--- a/tabwrap_test.go
+++ b/tabwrap_test.go
@@ -339,6 +339,7 @@ func TestFillLeft(t *testing.T) {
 		{"wider than width", "hello world", 5, "hello world"},
 		{"empty string", "", 3, "   "},
 		{"CJK", "日本", 6, "  日本"},
+		{"first line not widest", "a\nbc", 3, "  a\nbc"},
 		{"tab expands before left padding", "a\tb", 8, "   a   b"},
 		{"tab exact width unchanged", "a\tb", 5, "a\tb"},
 		{"only first line tabs expand", "a\tb\nc\td", 8, "   a   b\nc\td"},

--- a/tabwrap_test.go
+++ b/tabwrap_test.go
@@ -341,6 +341,7 @@ func TestFillLeft(t *testing.T) {
 		{"CJK", "日本", 6, "  日本"},
 		{"tab expands before left padding", "a\tb", 8, "   a   b"},
 		{"tab exact width unchanged", "a\tb", 5, "a\tb"},
+		{"only first line tabs expand", "a\tb\nc\td", 8, "   a   b\nc\td"},
 	}
 
 	for _, tt := range tests {

--- a/tabwrap_test.go
+++ b/tabwrap_test.go
@@ -302,6 +302,7 @@ func TestTruncate(t *testing.T) {
 		{"no truncation", "hello", 10, "...", "hello"},
 		{"exact fit", "hello", 5, "...", "hello"},
 		{"truncate with tail", "hello world", 8, "...", "hello..."},
+		{"truncate clamps wide tail", "hello", 1, "...", "."},
 		{"empty string", "", 5, "...", ""},
 		{"CJK truncate", "日本語テスト", 7, "...", "日本..."},
 		{"tab in string fits", "a\tb", 5, "...", "a   b"},
@@ -315,6 +316,9 @@ func TestTruncate(t *testing.T) {
 			got := c.Truncate(tt.s, tt.maxWidth, tt.tail)
 			if got != tt.want {
 				t.Errorf("Truncate(%q, %d, %q) = %q, want %q", tt.s, tt.maxWidth, tt.tail, got, tt.want)
+			}
+			if tt.maxWidth > 0 && c.StringWidth(got) > tt.maxWidth {
+				t.Errorf("Truncate(%q, %d, %q) visible width = %d, want <= %d", tt.s, tt.maxWidth, tt.tail, c.StringWidth(got), tt.maxWidth)
 			}
 		})
 	}
@@ -335,6 +339,8 @@ func TestFillLeft(t *testing.T) {
 		{"wider than width", "hello world", 5, "hello world"},
 		{"empty string", "", 3, "   "},
 		{"CJK", "日本", 6, "  日本"},
+		{"tab expands before left padding", "a\tb", 8, "   a   b"},
+		{"tab exact width unchanged", "a\tb", 5, "a\tb"},
 	}
 
 	for _, tt := range tests {
@@ -343,6 +349,9 @@ func TestFillLeft(t *testing.T) {
 			got := c.FillLeft(tt.s, tt.width)
 			if got != tt.want {
 				t.Errorf("FillLeft(%q, %d) = %q, want %q", tt.s, tt.width, got, tt.want)
+			}
+			if c.StringWidth(got) != max(c.StringWidth(tt.want), tt.width) {
+				t.Errorf("FillLeft(%q, %d) visible width = %d, want %d", tt.s, tt.width, c.StringWidth(got), max(c.StringWidth(tt.want), tt.width))
 			}
 		})
 	}
@@ -396,8 +405,14 @@ func TestPackageLevelFunctions(t *testing.T) {
 	if got := Truncate("hello world", 8, "..."); got != "hello..." {
 		t.Errorf("Truncate = %q, want %q", got, "hello...")
 	}
+	if got := Truncate("hello", 1, "..."); got != "." {
+		t.Errorf("Truncate wide tail = %q, want %q", got, ".")
+	}
 	if got := FillLeft("hi", 5); got != "   hi" {
 		t.Errorf("FillLeft = %q, want %q", got, "   hi")
+	}
+	if got := FillLeft("a\tb", 8); got != "   a   b" {
+		t.Errorf("FillLeft tab = %q, want %q", got, "   a   b")
 	}
 	if got := FillRight("hi", 5); got != "hi   " {
 		t.Errorf("FillRight = %q, want %q", got, "hi   ")


### PR DESCRIPTION
## Summary
- make `FillLeft` expand tabs before left padding so prepended spaces do not shift later tab stops
- clamp overly wide `Truncate` tails so truncated results still fit within positive `maxWidth`
- add regression tests for tabbed left padding and wide-tail truncation, and update the README wording for `Truncate`

## Context
- derived from follow-up review findings from Opus 4.6, Opus 4.7, and GPT-5.4

## Testing
- go test ./...